### PR TITLE
Remove slave's forced "default" storageClassName

### DIFF
--- a/activemq-artemis/templates/slave-statefulset.yaml
+++ b/activemq-artemis/templates/slave-statefulset.yaml
@@ -102,7 +102,7 @@ spec:
       name: data
     spec:
       accessModes: [ {{ .Values.persistence.accessMode | quote }} ]
-      storageClassName: {{ default "default" .Values.persistence.storageClass | quote }}
+      storageClassName: {{ .Values.persistence.storageClass | quote }}
       resources:
         requests:
           storage: {{ .Values.persistence.size }}


### PR DESCRIPTION
I think it's better to leave it the same as for master pvc, besides one may not have "default" storage class.