### PR TITLE
Config edits for failback

### DIFF
--- a/activemq-artemis/templates/master-configmap.yaml
+++ b/activemq-artemis/templates/master-configmap.yaml
@@ -15,7 +15,7 @@ data:
             <master>
               <group-name>to-be-set-by-configure-cluster.sh</group-name>
               <!--we need this for auto failback-->
-              <check-for-live-server>false</check-for-live-server>
+              <check-for-live-server>true</check-for-live-server>
             </master>
           </replication>
         </ha-policy>

--- a/activemq-artemis/templates/slave-configmap.yaml
+++ b/activemq-artemis/templates/slave-configmap.yaml
@@ -13,6 +13,8 @@ data:
           <replication>
             <slave>
               <group-name>to-be-set-by-configure-cluster.sh</group-name>
+              <allow-failback>true</allow-failback>
+              <failback-delay>5000</failback-delay>
             </slave>
           </replication>
         </ha-policy>


### PR DESCRIPTION
Addressing issue https://github.com/vromero/activemq-artemis-helm/issues/22

As per our tested production configuration, these changes allow for failback of the slave nodes to the master when the master comes back online.