### PR TITLE
Change default to all addresses

### DIFF
--- a/activemq-artemis/templates/configmap.yaml
+++ b/activemq-artemis/templates/configmap.yaml
@@ -29,7 +29,7 @@ data:
 
         <cluster-connections>
           <cluster-connection name="{{ $releaseName }}">
-            <address>jms</address>
+            <address></address>
             <connector-ref>netty-connector</connector-ref>
             <retry-interval>500</retry-interval>
             <retry-interval-multiplier>1.1</retry-interval-multiplier>


### PR DESCRIPTION
The cluster connection is currently set to only distribute messages to destinations starting with 'jms'. This has caught us out in the past, and the default for these charts should probably be to allow all addresses.