### PR TITLE
docker image DISABLE_SECURITY env variable as helm variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following tables lists the configurable parameters of the MySQL chart and th
 | `persistence.testJournalPerformance` | See docker image docs                 | `AUTO`                                                     |
 | `resources.request.memory`           | Memory resource requests/limits       | `256Mi`                                                    |
 | `resources.request.cpu`              | CPU/Memory resource requests/limits   | `100m`                                                     |
+| `disableSecurity`                    | Disables activeMQ security features   | `false`                                                    |
 
 Some of the parameters above map to the env variables defined in the [vromero's ActiveMQ Artemis image](https://hub.docker.com/r/vromero/activemq-artemis/) refer to it for values, meaning, etc.
 

--- a/activemq-artemis/Chart.yaml
+++ b/activemq-artemis/Chart.yaml
@@ -1,5 +1,5 @@
 name: activemq-artemis
-version: 0.0.1
+version: 0.1.1
 appVersion: 2.6.2
 description: a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
 keywords:

--- a/activemq-artemis/templates/master-statefulset.yaml
+++ b/activemq-artemis/templates/master-statefulset.yaml
@@ -68,6 +68,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+{{- if .Values.disableSecurity }}
+        - name: DISABLE_SECURITY
+          value: "true"
+{{- else }}
         - name: ARTEMIS_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -75,6 +79,7 @@ spec:
               key: artemis-password
         - name: ARTEMIS_USERNAME
           value: {{ default "artemis" .Values.artemisUser | quote }}
+{{- end }}
         - name: ARTEMIS_PERF_JOURNAL
           value: {{ default "AUTO" .Values.persistence.testJournalPerformance | quote }}
         - name: ENABLE_JMX_EXPORTER

--- a/activemq-artemis/templates/slave-statefulset.yaml
+++ b/activemq-artemis/templates/slave-statefulset.yaml
@@ -48,6 +48,10 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+{{- if .Values.disableSecurity }}
+        - name: DISABLE_SECURITY
+          value: "true"
+{{- else }}
         - name: ARTEMIS_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -55,6 +59,7 @@ spec:
               key: artemis-password
         - name: ARTEMIS_USERNAME
           value: {{ default "artemis" .Values.artemisUser | quote }}
+{{- end }}
         - name: ARTEMIS_PERF_JOURNAL
           value: {{ default "AUTO" .Values.persistence.testJournalPerformance | quote }}
         - name: ENABLE_JMX_EXPORTER

--- a/activemq-artemis/values.yaml
+++ b/activemq-artemis/values.yaml
@@ -12,6 +12,9 @@ image:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   pullSecrets: []
 
+# disableSecurity disables activeMQ security features
+disableSecurity: false
+
 # artemisUser sets the artemis admin user name
 artemisUser: artemis
 # artemisPassword sets the artemis admin user password


### PR DESCRIPTION
added new variable **disableSecurity** : this variable allows disabling the security features as described on [README.md](https://github.com/vromero/activemq-artemis-docker/blob/master/README.md#57-overriding-parts-of-the-configuration)  file of docker image.

To install the chart with the release name my-release without security features:

`helm install activemq-artemis/activemq-artemis --name my-release --set disableSecurity=true`

