### PR TITLE
fix connector to work with all addresses

### DIFF
--- a/activemq-artemis/templates/configmap.yaml
+++ b/activemq-artemis/templates/configmap.yaml
@@ -29,7 +29,6 @@ data:
 
         <cluster-connections>
           <cluster-connection name="{{ $releaseName }}">
-            <address>jms</address>
             <connector-ref>netty-connector</connector-ref>
             <retry-interval>500</retry-interval>
             <retry-interval-multiplier>1.1</retry-interval-multiplier>


### PR DESCRIPTION
@vromero nice chart!

I spent a chunk of time this weekend trying to figure out why messages weren't being properly distributed and redistributed. I eventually discovered the line that this PR proposes to remove constrains the connector to only working for addresses beginning `jms`-- which I assume was not the intended behavior.