### PR TITLE
Fix missing apiVersion in Chart.yaml

### DIFF
--- a/activemq-artemis/Chart.yaml
+++ b/activemq-artemis/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: activemq-artemis
 version: 0.0.1
 appVersion: 2.6.2


### PR DESCRIPTION
This pull request adds the missing field "apiVersion" to the Chart.yaml file. According to the helm docs this is a required field (see [helm v2 doc](https://v2.helm.sh/docs/developing_charts/#charts) and [helm v3 doc](https://helm.sh/docs/topics/charts/). I came across this issue by accident, as I was having some initial trouble getting this to install. Performing `helm lint activemq-artemis` showed 1 error - the missing apiVersion. It appears that this was not directly related to my initial troubles, but double checking the documentation of helm, it seems that adding this information would be advised. Note that I've tested this using helm 3, but this shouldn't be an issue, as the field is required in helm 2 as well.